### PR TITLE
Add Qt dashboard tab embedding realtime dashboard

### DIFF
--- a/Qt/main.py
+++ b/Qt/main.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import QMainWindow, QApplication, QTabWidget, QWidget, QVBoxLayout
 from PySide6.QtWebEngineWidgets import QWebEngineView
-from PySide6.QtCore import QUrl
+from PySide6.QtCore import QProcess, QUrl
 import sys
 import os
 import socket
@@ -66,6 +66,41 @@ class EmbeddedServer:
             print("Server stopped")
 
 
+class DashboardView(QWidget):
+    def __init__(self, project_root, parent=None):
+        super().__init__(parent)
+
+        self._project_root = project_root
+        self._pipeline_process = QProcess(self)
+
+        # Configure the pipeline process to run without opening an external browser
+        script_path = os.path.join(self._project_root, "scripts", "start_realtime_pipeline.py")
+        self._pipeline_process.setProgram(sys.executable)
+        self._pipeline_process.setArguments([script_path, "--no-browser"])
+        self._pipeline_process.setWorkingDirectory(self._project_root)
+        self._pipeline_process.start()
+
+        # Set up the embedded web view for the dashboard
+        dashboard_view = QWebEngineView(self)
+        dashboard_view.setUrl(QUrl("http://localhost:8080"))
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(dashboard_view)
+
+        self._dashboard_view = dashboard_view
+
+    def stop_pipeline(self):
+        if self._pipeline_process.state() != QProcess.NotRunning:
+            self._pipeline_process.terminate()
+            if not self._pipeline_process.waitForFinished(5000):
+                self._pipeline_process.kill()
+                self._pipeline_process.waitForFinished(2000)
+
+    def closeEvent(self, event):
+        self.stop_pipeline()
+        super().closeEvent(event)
+
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
@@ -97,11 +132,18 @@ class MainWindow(QMainWindow):
         plot_view = PlotView()
         tab_widget.addTab(plot_view, "Plot")
 
+        # Dashboard view
+        self.dashboard_view = DashboardView(project_root, self)
+        tab_widget.addTab(self.dashboard_view, "Dashboard")
+
         self.setCentralWidget(tab_widget)
     
     def closeEvent(self, event):
         """Handle application close event"""
         # Stop the embedded server when closing the app
+        if self.dashboard_view:
+            self.dashboard_view.stop_pipeline()
+
         if self.server:
             self.server.stop_server()
         super().closeEvent(event)

--- a/scripts/start_realtime_pipeline.py
+++ b/scripts/start_realtime_pipeline.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-Start the complete TRIAXUS real-time data processing pipeline
-"""
+"""Start the complete TRIAXUS real-time data processing pipeline."""
 
-import subprocess
-import time
-import sys
+import argparse
 import os
 import signal
+import subprocess
+import sys
+import time
 import webbrowser
 from pathlib import Path
 
@@ -17,6 +16,20 @@ project_root = Path(__file__).parent.parent
 # Add project root to Python path
 import sys
 sys.path.insert(0, str(project_root))
+
+def parse_args(argv=None):
+    """Parse command line arguments for the pipeline starter."""
+
+    parser = argparse.ArgumentParser(
+        description="Start the TRIAXUS real-time data processing pipeline."
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not automatically open the realtime dashboard in the default browser.",
+    )
+    return parser.parse_args(argv)
+
 
 def start_process(command, cwd=None, background=True):
     """Start a process and return the process object"""
@@ -41,8 +54,9 @@ def check_database():
         print(f"✗ Database connection failed: {e}")
         return False
 
-def main():
+def main(argv=None):
     """Start the complete real-time pipeline"""
+    args = parse_args(argv)
     print("=" * 60)
     print("TRIAXUS Real-time Data Processing Pipeline")
     print("=" * 60)
@@ -93,7 +107,8 @@ def main():
         # Step 4: Open dashboard
         print("\n4. Opening dashboard...")
         dashboard_url = "http://localhost:8080"
-        webbrowser.open(dashboard_url)
+        if not args.no_browser:
+            webbrowser.open(dashboard_url)
         
         print("\n" + "=" * 60)
         print("Pipeline started successfully!")


### PR DESCRIPTION
## Summary
- add a Dashboard tab to the Qt application that embeds the realtime dashboard URL
- launch and clean up the realtime pipeline from Qt via QProcess
- allow the realtime pipeline script to skip opening the external browser with a --no-browser flag

## Testing
- python -m compileall Qt/main.py scripts/start_realtime_pipeline.py